### PR TITLE
feat: add event binding

### DIFF
--- a/features/require/require.js
+++ b/features/require/require.js
@@ -332,9 +332,7 @@
 
           parent.childrenRequire.push(ractive);
 
-          for (var event in databinding.events) {
-            _fireBindedEvent(parent, ractive, databinding, event);
-          }
+          _fireBindedEvent(parent, ractive, databinding);
 
           return ractive;
         }, databinding.data, element, {
@@ -349,12 +347,19 @@
       });
   }
 
-  function _fireBindedEvent(parent, ractive, databinding, event){
-    var eventName = databinding.events[event];
+  function _fireBindedEvent(parent, ractive, databinding){
+    var fireevent = function(name){
+      ractive.on(event, function(e){
+        parent.fire(name, e);
+      });
+    }
 
-    ractive.on(event, function(e){
-      parent.fire(eventName, e);
-    });
+    for (var event in databinding.events) {
+      if (!databinding.events.hasOwnProperty(event))
+        continue;
+
+      fireevent(databinding.events[event]);
+    }
   }
 
   function _inScope(element, parent) {

--- a/features/require/require.js
+++ b/features/require/require.js
@@ -54,27 +54,33 @@
   }
 
   function _fetchDataBinding(element, parent) {
-    var data = {},
-        binds = {},
+    var data   = {},
+        binds  = {},
+        events = {},
         attr,
         name;
 
     for (var i = 0; i < element.attributes.length; i++) {
       attr = element.attributes[i];
-      if (attr.name.indexOf('data-bind-') === 0) {
-        name = attr.name.substr(10, attr.name.length - 10);
-        data[name] = parent.get(attr.value);
+      if (attr.name.indexOf('data-on-') === 0){
+        name         = attr.name.substr(8, attr.name.length - 8);
+        events[name] = attr.value;
+      }
+      else if (attr.name.indexOf('data-bind-') === 0) {
+        name        = attr.name.substr(10, attr.name.length - 10);
+        data[name]  = parent.get(attr.value);
         binds[name] = attr.value;
       }
       else if (attr.name.indexOf('data-') === 0) {
-        name = attr.name.substr(5, attr.name.length - 5);
+        name       = attr.name.substr(5, attr.name.length - 5);
         data[name] = attr.value;
       }
     }
 
     return {
-      data: data,
-      binds: binds
+      data   :data,
+      binds  :binds,
+      events :events,
     };
   }
 
@@ -326,6 +332,10 @@
 
           parent.childrenRequire.push(ractive);
 
+          for (var event in databinding.events) {
+            _fireBindedEvent(parent, ractive, databinding, event);
+          }
+
           return ractive;
         }, databinding.data, element, {
           template: template,
@@ -337,6 +347,14 @@
         });
 
       });
+  }
+
+  function _fireBindedEvent(parent, ractive, databinding, event){
+    var eventName = databinding.events[event];
+
+    ractive.on(event, function(e){
+      parent.fire(eventName, e);
+    });
   }
 
   function _inScope(element, parent) {


### PR DESCRIPTION
#### add event binding through the data-on-?? property

example situation:

I require a complicated widget and wish to handle the `resetdata` and `sortdata` events in the requiring parent html.

The `resetdata` event will be handled by the `widgetDataReset` function, and the `sortdata` event will be handled by the `widgetDataSort` function.

``` html
<!-- main.html -->
<rv-require name="myComplicatedWidget"
            src="/widgets/myComplicatedControl"
            data-xx="xxdata"
            data-yy="yydata"
            data-zz="zzdata"
            data-on-resetdata="widgetDataReset"
            data-on-sortdata="widgetDataSort"></rv-require>
```

``` javascript
// main.js
mainRactive.on("widgetDataReset", function(e){
    //do something, perhaps update the data of other
    //widgets or send ajax or move to another page or what not
});

mainRactive.on("widgetDataSort", function(e){
    //do something, perhaps update the data of other
    //widgets or send ajax or move to another page or what not
});
```

myComplicatedWidget has a reset and a sort button.

The reset button directly passes the click event to the parent (main.html) and the sort button handles the click event internally (myComplicatedWidget.js) and then propagates it to the parent.

``` html
<!-- myComplicatedWidget.html -->
<div name="{{ xx }}" id="{{ yy }}">{{ zz }}</div>
<input type="button"
       value="reset"
       on-click="resetdata" /> 
<input type="button"
       value="sort"
       on-click="sortWidget" />
```

``` javascript
// myComplicatedWidget.js
widgetRactive.on("sortWidget", function(e){
    //do some data manipulation or show a dialog
    //or check the data or what not

    //propagate it to the parent
    widgetRactive.fire("sortdata", e);
});
```
