### PR TITLE
feat(require):add the child's instance as an argument

### DIFF
--- a/features/require/require.js
+++ b/features/require/require.js
@@ -351,7 +351,7 @@
   function _fireBindedEvent(parent, ractive, databinding) {
     var fireevent = function(event, name) {
       ractive.on(event, function() {
-        Array.prototype.unshift.call(arguments, name);
+        Array.prototype.unshift.call(arguments, name, ractive);
 
         parent.fire.apply(parent, arguments);
       });


### PR DESCRIPTION
Most of the time I need the ractive instace or the required child.

My parent's handler would look like

``` javascript
var onChildEvent = function(e){
    //get the child
    var childRactive = thisRactive.findChildren("id", "childID");

    //do something with the child
    childRactive.get(....);

    ...   
};

```

This became quite a pain since I have a very complicated widget with lots of binded events.

With this patch I could ease my work a bit since I don't have to manage the elements id and have to call `findChildren` (unless I really need to find my lost child)

The new and improved code would be

``` javascript
var onChildEvent = function(r, e){
    //no need to track ids anymore
    var childRactive = r;
    childRactive.get(....);

    ...   
};

```
