### PR TITLE
feat(require): bind multiple events with single common handler

### DIFF
--- a/features/require/require.js
+++ b/features/require/require.js
@@ -66,11 +66,17 @@
 
       if (attr.name.indexOf('data-on-') === 0) {
         name = attr.name.substr(8, attr.name.length - 8);
-        events[name] = attr.value;
+        name.split("-").map(function(eventName) {
+          if (eventName.trim() !== "")
+            events[eventName] = attr.value;
+        });
       }
       else if (attr.name.indexOf('data-listen-') === 0) {
         name = attr.name.substr(12, attr.name.length - 12);
-        listening[name] = attr.value;
+        name.split("-").map(function(eventName) {
+          if (eventName.trim() !== "")
+            listening[eventName] = attr.value;
+        });
       }
       else if (attr.name.indexOf('data-bind-') === 0) {
         name = attr.name.substr(10, attr.name.length - 10);

--- a/features/require/require.js
+++ b/features/require/require.js
@@ -66,15 +66,15 @@
 
       if (attr.name.indexOf('data-on-') === 0) {
         name = attr.name.substr(8, attr.name.length - 8);
-        name.split("-").map(function(eventName) {
-          if (eventName.trim() !== "")
+        name.split("-").forEach(function(eventName) {
+          if (eventName.trim())
             events[eventName] = attr.value;
         });
       }
       else if (attr.name.indexOf('data-listen-') === 0) {
         name = attr.name.substr(12, attr.name.length - 12);
-        name.split("-").map(function(eventName) {
-          if (eventName.trim() !== "")
+        name.split("-").forEach(function(eventName) {
+          if (eventName.trim())
             listening[eventName] = attr.value;
         });
       }

--- a/features/require/require.js
+++ b/features/require/require.js
@@ -66,16 +66,18 @@
 
       if (attr.name.indexOf('data-on-') === 0) {
         name = attr.name.substr(8, attr.name.length - 8);
-        name.split("-").forEach(function(eventName) {
-          if (eventName.trim())
+        name.split('-').forEach(function(eventName) {
+          if (eventName.trim()) {
             events[eventName] = attr.value;
+          }
         });
       }
       else if (attr.name.indexOf('data-listen-') === 0) {
         name = attr.name.substr(12, attr.name.length - 12);
-        name.split("-").forEach(function(eventName) {
-          if (eventName.trim())
+        name.split('-').forEach(function(eventName) {
+          if (eventName.trim()) {
             listening[eventName] = attr.value;
+          }
         });
       }
       else if (attr.name.indexOf('data-bind-') === 0) {


### PR DESCRIPTION
I was browsing through the Ractive documentation and saw

``` html
<div on-mouseover-mousemove='set( "hover", true )'>...</div>
```

and I thought that

``` html
data-on-childevent1-childevent2-....="parentevent"
<!-- when any of the childeventN is fired parentevent will get fired -->
```

``` html
data-listen-childevent1-childevent2-...="parentevent"
<!-- when parentevent is fired all of the childeventNs will also get fired -->
```

could also be possible.

Here's a sample on how I use it:

``` html
<rv-require name="dataList"
            src="widgets/data-list"
            data-title="等級色分類"
            data-addbtnlabel="追加・変更"
            data-sortable="false"
            data-on-resetdata-cleardata="clear-list-data"
            data-listen-clearselected-resetrange="clear-ranges"></rv-require>
```
